### PR TITLE
quick fix, to ignore broken data

### DIFF
--- a/bunnycdn_exporter.go
+++ b/bunnycdn_exporter.go
@@ -84,6 +84,9 @@ func (s bunnyStatistics) trafficLocations() []bunnyLocation {
 	locations := make([]bunnyLocation, 0, len(s.GeoTrafficDistribution))
 	for loc, req := range s.GeoTrafficDistribution {
 		parts := strings.Split(loc, ":")
+		if len(parts) < 2 {
+			continue
+		}
 		locations = append(
 			locations,
 			bunnyLocation{


### PR DESCRIPTION
Slack: https://ricardo-ch.slack.com/archives/C4J3A4S3W/p1643022818007800

Calling this:
GET https://api.bunny.net/statistics?loadErrors=false&hourly=false
return this:
```
{
...
  "GeoTrafficDistribution": {
    "EU: London, UK": 350687851447,
    "EU: Marseille, FR": 44668450139,
    "EU: Chisinau, MD": 782002145,
    "EU: Khabarovsk, RU": 488756,
    "Asia, Nicosia, CY": 1022, // <--- Problem, as we are splitting string on :
    "EU: Novi Travnik, BA": 2252224279,
    "Asia: Tbilisi, GE": 1031,
    "EU: Riga, LV": 34565150,
    "EU: Budapest, HU": 103394141105,
    "Asia: Baku, AZ": 1022,
....
}
```

quick fix(hack) to skip entries which are not in format “<continent>:<town>, <code>” and as well I’ll open support ticket